### PR TITLE
Define actuation msg for Actuation subteam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(DIRECTORY msg
    FILES
    cone_msg.msg
-   actuation.msg
+   actuation_msg.msg
  )
 
 generate_messages(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(DIRECTORY msg
    FILES
    cone_msg.msg
+   actuation.msg
  )
 
 generate_messages(

--- a/msg/actuation.msg
+++ b/msg/actuation.msg
@@ -1,0 +1,2 @@
+float32 acceleration_threshold
+float32 steering

--- a/msg/actuation.msg
+++ b/msg/actuation.msg
@@ -1,2 +1,0 @@
-float32 acceleration_threshold
-float32 steering

--- a/msg/actuation_msg.msg
+++ b/msg/actuation_msg.msg
@@ -1,0 +1,10 @@
+# Timestamp in case EMC needs it
+Header header
+
+# acceleration_threshold goes from [-1, 1], where 
+# -1 denotes max. braking and 1 denotes max. acceleration. 
+# Anything > 0 is acceleration, while <= 0 should be treated as braking.
+float32 acceleration_threshold
+
+# steering is defined in terms of raw radians value, not threshold.
+float32 steering


### PR DESCRIPTION
This message will be published by [`path_follower_ros`](https://github.com/MURDriverless/path_follower_ros) node, and subscribed by a node interfacing with the motors.

- acceleration_threshold goes from [-1, 1], where -1 denotes max. braking and 1 denotes max. acceleration. Anything > 0 is acceleration, while <= 0 should be treated as braking.

- steering is defined in terms of raw radians value, not threshold.